### PR TITLE
feat: Raise file truncation limit to 5000 lines (configurable)

### DIFF
--- a/src/HVO.AiCodeReview/Models/AiProviderSettings.cs
+++ b/src/HVO.AiCodeReview/Models/AiProviderSettings.cs
@@ -16,6 +16,13 @@ public class AiProviderSettings
     public int MaxParallelReviews { get; set; } = 5;
 
     /// <summary>
+    /// Default maximum number of source lines sent to AI per file.
+    /// Files longer than this are truncated with a marker.
+    /// Can be overridden per-provider via <see cref="ProviderConfig.MaxInputLinesPerFile"/>.
+    /// </summary>
+    public int MaxInputLinesPerFile { get; set; } = 5000;
+
+    /// <summary>
     /// The review mode: "single" uses one provider; "consensus" fans out to
     /// multiple providers and merges results.
     /// </summary>
@@ -77,4 +84,10 @@ public class ProviderConfig
     /// a provider without removing its config.
     /// </summary>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Per-provider override for the maximum source lines sent to AI per file.
+    /// When null, the global <see cref="AiProviderSettings.MaxInputLinesPerFile"/> is used.
+    /// </summary>
+    public int? MaxInputLinesPerFile { get; set; }
 }

--- a/src/HVO.AiCodeReview/Services/AzureOpenAiReviewService.cs
+++ b/src/HVO.AiCodeReview/Services/AzureOpenAiReviewService.cs
@@ -18,6 +18,7 @@ public class AzureOpenAiReviewService : ICodeReviewService
     private readonly ChatClient _chatClient;
     private readonly string _systemPrompt;
     private readonly string _singleFileSystemPrompt;
+    private readonly int _maxInputLinesPerFile;
 
     // ── Legacy constructor: used by direct DI registration via IOptions ──
 
@@ -29,7 +30,8 @@ public class AzureOpenAiReviewService : ICodeReviewService
             settings.Value.ApiKey,
             settings.Value.DeploymentName,
             settings.Value.CustomInstructionsPath,
-            logger)
+            logger,
+            maxInputLinesPerFile: 5000)
     { }
 
     // ── Factory constructor: used by CodeReviewServiceFactory from ProviderConfig ──
@@ -39,10 +41,12 @@ public class AzureOpenAiReviewService : ICodeReviewService
         string apiKey,
         string modelName,
         string? customInstructionsPath,
-        ILogger<AzureOpenAiReviewService> logger)
+        ILogger<AzureOpenAiReviewService> logger,
+        int maxInputLinesPerFile = 5000)
     {
         _modelName = modelName;
         _logger = logger;
+        _maxInputLinesPerFile = maxInputLinesPerFile;
 
         var client = new AzureOpenAIClient(
             new Uri(endpoint),
@@ -53,8 +57,8 @@ public class AzureOpenAiReviewService : ICodeReviewService
         // Build system prompts
         _systemPrompt = BuildSystemPrompt(customInstructionsPath);
         _singleFileSystemPrompt = BuildSingleFileSystemPrompt(customInstructionsPath);
-        _logger.LogInformation("[{Provider}] System prompts assembled (multi-file: {MultiLen} chars, single-file: {SingleLen} chars)",
-            modelName, _systemPrompt.Length, _singleFileSystemPrompt.Length);
+        _logger.LogInformation("[{Provider}] System prompts assembled (multi-file: {MultiLen} chars, single-file: {SingleLen} chars, max input lines/file: {MaxLines})",
+            modelName, _systemPrompt.Length, _singleFileSystemPrompt.Length, _maxInputLinesPerFile);
     }
 
     public async Task<CodeReviewResult> ReviewAsync(PullRequestInfo pullRequest, List<FileChange> fileChanges, List<WorkItemInfo>? workItems = null)
@@ -792,7 +796,7 @@ public class AzureOpenAiReviewService : ICodeReviewService
                 to this file, omit the field entirely. If NO work items were provided, omit it.
             """;
 
-    private static string BuildUserPrompt(PullRequestInfo pr, List<FileChange> fileChanges, List<WorkItemInfo>? workItems = null)
+    private string BuildUserPrompt(PullRequestInfo pr, List<FileChange> fileChanges, List<WorkItemInfo>? workItems = null)
     {
         var sb = new System.Text.StringBuilder();
 
@@ -884,7 +888,7 @@ public class AzureOpenAiReviewService : ICodeReviewService
     /// Build a user prompt for reviewing a single file in isolation.
     /// Includes PR context for relevance but only contains one file's content.
     /// </summary>
-    private static string BuildSingleFileUserPrompt(PullRequestInfo pr, FileChange file, int totalFilesInPr, List<WorkItemInfo>? workItems = null)
+    private string BuildSingleFileUserPrompt(PullRequestInfo pr, FileChange file, int totalFilesInPr, List<WorkItemInfo>? workItems = null)
     {
         var sb = new System.Text.StringBuilder();
 
@@ -981,15 +985,16 @@ public class AzureOpenAiReviewService : ICodeReviewService
 
     /// <summary>
     /// Truncate very large files to avoid exceeding token limits.
+    /// Uses the configured <see cref="_maxInputLinesPerFile"/> threshold.
     /// </summary>
-    private static string TruncateContent(string content, int maxLines = 500)
+    private string TruncateContent(string content)
     {
         var lines = content.Split('\n');
-        if (lines.Length <= maxLines)
+        if (lines.Length <= _maxInputLinesPerFile)
             return content;
 
-        var truncated = string.Join('\n', lines.Take(maxLines));
-        return truncated + $"\n\n... [truncated: {lines.Length - maxLines} more lines] ...";
+        var truncated = string.Join('\n', lines.Take(_maxInputLinesPerFile));
+        return truncated + $"\n\n... [truncated: {lines.Length - _maxInputLinesPerFile} more lines] ...";
     }
 
     /// <summary>

--- a/src/HVO.AiCodeReview/Services/CodeReviewServiceFactory.cs
+++ b/src/HVO.AiCodeReview/Services/CodeReviewServiceFactory.cs
@@ -52,7 +52,8 @@ public static class CodeReviewServiceFactory
                     legacySettings.ApiKey,
                     legacySettings.DeploymentName,
                     legacySettings.CustomInstructionsPath,
-                    logger);
+                    logger,
+                    maxInputLinesPerFile: settings.MaxInputLinesPerFile);
             }
 
             // Build all enabled providers
@@ -60,7 +61,7 @@ public static class CodeReviewServiceFactory
                 .Where(kv => kv.Value.Enabled)
                 .Select(kv => (
                     Name: kv.Value.DisplayName.Length > 0 ? kv.Value.DisplayName : kv.Key,
-                    Service: CreateProvider(kv.Key, kv.Value, loggerFactory)))
+                    Service: CreateProvider(kv.Key, kv.Value, loggerFactory, settings.MaxInputLinesPerFile)))
                 .ToList();
 
             if (providers.Count == 0)
@@ -115,9 +116,10 @@ public static class CodeReviewServiceFactory
     /// Extend this method when adding new provider types.
     /// </summary>
     private static ICodeReviewService CreateProvider(
-        string key, ProviderConfig config, ILoggerFactory loggerFactory)
+        string key, ProviderConfig config, ILoggerFactory loggerFactory, int globalMaxInputLines)
     {
         var type = config.Type.ToLowerInvariant();
+        var maxLines = config.MaxInputLinesPerFile ?? globalMaxInputLines;
 
         return type switch
         {
@@ -126,7 +128,8 @@ public static class CodeReviewServiceFactory
                 config.ApiKey,
                 config.Model,
                 config.CustomInstructionsPath,
-                loggerFactory.CreateLogger<AzureOpenAiReviewService>()),
+                loggerFactory.CreateLogger<AzureOpenAiReviewService>(),
+                maxInputLinesPerFile: maxLines),
 
             // ── Add new provider types here ──────────────────────────────
             // "github-copilot" => new GitHubCopilotReviewService(config, loggerFactory.CreateLogger<GitHubCopilotReviewService>()),

--- a/src/HVO.AiCodeReview/appsettings.json
+++ b/src/HVO.AiCodeReview/appsettings.json
@@ -23,6 +23,7 @@
   },
   "AiProvider": {
     "MaxParallelReviews": 5,
+    "MaxInputLinesPerFile": 5000,
     "Mode": "single",
     "ActiveProvider": "azure-openai",
     "ConsensusThreshold": 2,

--- a/tests/HVO.AiCodeReview.Tests/TruncationConfigTests.cs
+++ b/tests/HVO.AiCodeReview.Tests/TruncationConfigTests.cs
@@ -1,0 +1,232 @@
+using AiCodeReview.Models;
+using AiCodeReview.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AiCodeReview.Tests;
+
+/// <summary>
+/// Tests for Issue #5 — configurable file truncation limit.
+/// Validates that MaxInputLinesPerFile flows through settings, factory, and
+/// the review service's prompt builder.
+/// </summary>
+[TestClass]
+public class TruncationConfigTests
+{
+    // ── AC-1: Default is 5000 ──────────────────────────────────────────
+
+    [TestMethod]
+    public void AiProviderSettings_Default_MaxInputLinesPerFile_Is5000()
+    {
+        var settings = new AiProviderSettings();
+        Assert.AreEqual(5000, settings.MaxInputLinesPerFile,
+            "Global default must be 5 000 lines.");
+    }
+
+    [TestMethod]
+    public void ProviderConfig_Default_MaxInputLinesPerFile_IsNull()
+    {
+        var config = new ProviderConfig();
+        Assert.IsNull(config.MaxInputLinesPerFile,
+            "Per-provider override must default to null (inherit global).");
+    }
+
+    // ── AC-2: Config binds from appsettings ────────────────────────────
+
+    [TestMethod]
+    public void AppsettingsJson_Binds_MaxInputLinesPerFile()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AiProvider:MaxInputLinesPerFile"] = "3000",
+                ["AiProvider:MaxParallelReviews"] = "5",
+                ["AiProvider:Mode"] = "single",
+                ["AiProvider:ActiveProvider"] = "azure-openai",
+            })
+            .Build();
+
+        var settings = config.GetSection("AiProvider").Get<AiProviderSettings>()!;
+        Assert.AreEqual(3000, settings.MaxInputLinesPerFile);
+    }
+
+    [TestMethod]
+    public void AppsettingsJson_Binds_ProviderLevel_MaxInputLinesPerFile()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AiProvider:Providers:myProvider:Type"] = "azure-openai",
+                ["AiProvider:Providers:myProvider:MaxInputLinesPerFile"] = "8000",
+            })
+            .Build();
+
+        var settings = config.GetSection("AiProvider").Get<AiProviderSettings>()!;
+        var provider = settings.Providers["myProvider"];
+        Assert.AreEqual(8000, provider.MaxInputLinesPerFile);
+    }
+
+    // ── AC-3: Truncation behaviour at the new limit ────────────────────
+
+    [TestMethod]
+    public void TruncateContent_BelowLimit_ReturnsUnchanged()
+    {
+        var service = CreateServiceWithMaxLines(100);
+        var content = GenerateLines(99);
+        var result = InvokeTruncate(service, content);
+        Assert.AreEqual(content, result, "Content under the limit must not be altered.");
+    }
+
+    [TestMethod]
+    public void TruncateContent_ExactlyAtLimit_ReturnsUnchanged()
+    {
+        var service = CreateServiceWithMaxLines(100);
+        var content = GenerateLines(100);
+        var result = InvokeTruncate(service, content);
+        Assert.AreEqual(content, result, "Content exactly at the limit must not be altered.");
+    }
+
+    [TestMethod]
+    public void TruncateContent_AboveLimit_Truncates_And_ShowsMarker()
+    {
+        var service = CreateServiceWithMaxLines(100);
+        var content = GenerateLines(250);
+        var result = InvokeTruncate(service, content);
+
+        var resultLines = result.Split('\n');
+        // First 100 data lines + 1 blank + 1 marker = 102, but the marker is on its own line
+        Assert.IsTrue(result.Contains("... [truncated: 150 more lines] ..."),
+            $"Truncation marker must show 150 remaining lines. Got:\n{result[^200..]}");
+        // Verify we kept exactly 100 source lines
+        Assert.IsTrue(result.StartsWith("Line 1\n"), "Must start with the first line.");
+        Assert.IsTrue(result.Contains("Line 100\n"), "Must include line 100.");
+        Assert.IsFalse(result.Contains("Line 101\n"), "Must NOT include line 101.");
+    }
+
+    [TestMethod]
+    public void TruncateContent_DefaultLimit_5000_AllowsLargeFiles()
+    {
+        // Use default (5000)
+        var service = CreateServiceWithMaxLines(5000);
+        var content = GenerateLines(4999);
+        var result = InvokeTruncate(service, content);
+        Assert.AreEqual(content, result, "4999-line file should pass through with 5000-line limit.");
+    }
+
+    [TestMethod]
+    public void TruncateContent_CustomLimit_AppliesCorrectly()
+    {
+        var service = CreateServiceWithMaxLines(200);
+        var content = GenerateLines(300);
+        var result = InvokeTruncate(service, content);
+        Assert.IsTrue(result.Contains("... [truncated: 100 more lines] ..."),
+            "Custom limit of 200 should truncate 300-line content.");
+        Assert.IsTrue(result.Contains("Line 200\n"), "Must include line 200.");
+        Assert.IsFalse(result.Contains("Line 201\n"), "Must NOT include line 201.");
+    }
+
+    // ── AC-4: Factory wires the value correctly ────────────────────────
+
+    [TestMethod]
+    public void Factory_PassesGlobalMaxInputLinesToProvider()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AiProvider:MaxInputLinesPerFile"] = "7500",
+                ["AiProvider:Mode"] = "single",
+                ["AiProvider:ActiveProvider"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Type"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Endpoint"] = "https://fake.openai.azure.com/",
+                ["AiProvider:Providers:azure-openai:ApiKey"] = "fake-key",
+                ["AiProvider:Providers:azure-openai:Model"] = "gpt-4o",
+                ["AiProvider:Providers:azure-openai:Enabled"] = "true",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddCodeReviewService(config);
+
+        var sp = services.BuildServiceProvider();
+        var service = sp.GetRequiredService<ICodeReviewService>();
+        Assert.IsInstanceOfType(service, typeof(AzureOpenAiReviewService));
+
+        // Verify the limit is wired by testing truncation behaviour
+        var content = GenerateLines(7501);
+        var result = InvokeTruncate((AzureOpenAiReviewService)service, content);
+        Assert.IsTrue(result.Contains("[truncated:"),
+            "7501-line content should be truncated at configured limit of 7500.");
+    }
+
+    [TestMethod]
+    public void Factory_ProviderOverride_TakesPrecedence()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AiProvider:MaxInputLinesPerFile"] = "5000",
+                ["AiProvider:Mode"] = "single",
+                ["AiProvider:ActiveProvider"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Type"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Endpoint"] = "https://fake.openai.azure.com/",
+                ["AiProvider:Providers:azure-openai:ApiKey"] = "fake-key",
+                ["AiProvider:Providers:azure-openai:Model"] = "gpt-4o",
+                ["AiProvider:Providers:azure-openai:Enabled"] = "true",
+                ["AiProvider:Providers:azure-openai:MaxInputLinesPerFile"] = "1000",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddCodeReviewService(config);
+
+        var sp = services.BuildServiceProvider();
+        var service = (AzureOpenAiReviewService)sp.GetRequiredService<ICodeReviewService>();
+
+        // Provider override = 1000, so 1001 lines should truncate
+        var content = GenerateLines(1001);
+        var result = InvokeTruncate(service, content);
+        Assert.IsTrue(result.Contains("[truncated: 1 more lines]"),
+            "Provider-level override (1000) should take precedence over global (5000).");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates an <see cref="AzureOpenAiReviewService"/> with a specific
+    /// truncation limit. Uses a fake endpoint — we only exercise prompt
+    /// building, not the AI call itself.
+    /// </summary>
+    private static AzureOpenAiReviewService CreateServiceWithMaxLines(int maxLines)
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
+        return new AzureOpenAiReviewService(
+            "https://fake.openai.azure.com/",
+            "fake-key",
+            "gpt-4o",
+            customInstructionsPath: null,
+            loggerFactory.CreateLogger<AzureOpenAiReviewService>(),
+            maxInputLinesPerFile: maxLines);
+    }
+
+    /// <summary>
+    /// Invokes the private <c>TruncateContent</c> method via reflection.
+    /// </summary>
+    private static string InvokeTruncate(AzureOpenAiReviewService service, string content)
+    {
+        var method = typeof(AzureOpenAiReviewService)
+            .GetMethod("TruncateContent",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.IsNotNull(method, "TruncateContent method must exist as a non-public instance method.");
+        return (string)method.Invoke(service, new object[] { content })!;
+    }
+
+    /// <summary>Generate a string with the specified number of newline-separated lines.</summary>
+    private static string GenerateLines(int count)
+    {
+        return string.Join('\n', Enumerable.Range(1, count).Select(i => $"Line {i}"));
+    }
+}


### PR DESCRIPTION
## Summary
Raises the file truncation limit from 500 to 5,000 lines and makes it configurable via `AiProviderSettings.MaxInputLinesPerFile`.

## Changes
- **AiProviderSettings**: Added `MaxInputLinesPerFile` property (default: 5000)
- **ProviderConfig**: Added nullable `MaxInputLinesPerFile` for per-provider override
- **AzureOpenAiReviewService**: `TruncateContent` now uses instance field instead of hardcoded default; constructor accepts `maxInputLinesPerFile` parameter
- **CodeReviewServiceFactory**: Resolves global and per-provider values, passes to service constructor
- **appsettings.json**: Added `MaxInputLinesPerFile: 5000` under `AiProvider`

## Tests
11 new unit tests in `TruncationConfigTests.cs`:
- Default values (5000 global, null per-provider)
- Config binding from appsettings
- Truncation below/at/above limit
- Custom limit application
- Factory wiring (global and per-provider override)

Closes #5