### PR TITLE
feat: Configurable Review Profile (#8)

### DIFF
--- a/src/HVO.AiCodeReview/Models/ReviewProfile.cs
+++ b/src/HVO.AiCodeReview/Models/ReviewProfile.cs
@@ -1,0 +1,68 @@
+namespace AiCodeReview.Models;
+
+/// <summary>
+/// Configurable review parameters that tune AI review behaviour.
+/// Bind to the <c>ReviewProfile</c> section in appsettings.json.
+/// All values have backward-compatible defaults matching the previous hardcoded values.
+/// </summary>
+public class ReviewProfile
+{
+    public const string SectionName = "ReviewProfile";
+
+    /// <summary>
+    /// AI temperature (0.0 = deterministic, 1.0 = creative).
+    /// Lower values produce more consistent, less creative reviews.
+    /// Default: 0.1 (highly deterministic).
+    /// </summary>
+    public float Temperature { get; set; } = 0.1f;
+
+    /// <summary>
+    /// Maximum output tokens for batch (multi-file) review calls.
+    /// Default: 16000.
+    /// </summary>
+    public int MaxOutputTokensBatch { get; set; } = 16000;
+
+    /// <summary>
+    /// Maximum output tokens for single-file review calls.
+    /// Default: 4000.
+    /// </summary>
+    public int MaxOutputTokensSingleFile { get; set; } = 4000;
+
+    /// <summary>
+    /// Maximum output tokens for thread verification calls.
+    /// Default: 2000.
+    /// </summary>
+    public int MaxOutputTokensVerification { get; set; } = 2000;
+
+    /// <summary>
+    /// Maximum output tokens for Pass 1 (PR summary) calls.
+    /// Default: 4000.
+    /// </summary>
+    public int MaxOutputTokensPrSummary { get; set; } = 4000;
+
+    /// <summary>
+    /// Verdict threshold configuration for future system-level verdict overrides.
+    /// Currently aspirational — the AI determines the verdict in its JSON response.
+    /// </summary>
+    public VerdictThresholds VerdictThresholds { get; set; } = new();
+}
+
+/// <summary>
+/// Thresholds for system-level verdict override (aspirational).
+/// When the system counts enough critical or warning issues, it can
+/// override the AI's verdict. Currently informational only.
+/// </summary>
+public class VerdictThresholds
+{
+    /// <summary>
+    /// Number of critical-severity inline comments that triggers a REJECTED verdict.
+    /// Default: 1 (one critical issue → reject).
+    /// </summary>
+    public int RejectOnCriticalCount { get; set; } = 1;
+
+    /// <summary>
+    /// Number of warning-severity inline comments that triggers a NEEDS WORK verdict.
+    /// Default: 3.
+    /// </summary>
+    public int NeedsWorkOnWarningCount { get; set; } = 3;
+}

--- a/src/HVO.AiCodeReview/Services/AzureOpenAiReviewService.cs
+++ b/src/HVO.AiCodeReview/Services/AzureOpenAiReviewService.cs
@@ -20,6 +20,7 @@ public class AzureOpenAiReviewService : ICodeReviewService
     private readonly string _singleFileSystemPrompt;
     private readonly string _prSummarySystemPrompt;
     private readonly int _maxInputLinesPerFile;
+    private readonly ReviewProfile _reviewProfile;
 
     // ── Legacy constructor: used by direct DI registration via IOptions ──
 
@@ -32,7 +33,8 @@ public class AzureOpenAiReviewService : ICodeReviewService
             settings.Value.DeploymentName,
             settings.Value.CustomInstructionsPath,
             logger,
-            maxInputLinesPerFile: 5000)
+            maxInputLinesPerFile: 5000,
+            reviewProfile: null)
     { }
 
     // ── Factory constructor: used by CodeReviewServiceFactory from ProviderConfig ──
@@ -43,11 +45,13 @@ public class AzureOpenAiReviewService : ICodeReviewService
         string modelName,
         string? customInstructionsPath,
         ILogger<AzureOpenAiReviewService> logger,
-        int maxInputLinesPerFile = 5000)
+        int maxInputLinesPerFile = 5000,
+        ReviewProfile? reviewProfile = null)
     {
         _modelName = modelName;
         _logger = logger;
         _maxInputLinesPerFile = maxInputLinesPerFile;
+        _reviewProfile = reviewProfile ?? new ReviewProfile();
 
         var client = new AzureOpenAIClient(
             new Uri(endpoint),
@@ -59,8 +63,9 @@ public class AzureOpenAiReviewService : ICodeReviewService
         _systemPrompt = BuildSystemPrompt(customInstructionsPath);
         _singleFileSystemPrompt = BuildSingleFileSystemPrompt(customInstructionsPath);
         _prSummarySystemPrompt = BuildPrSummarySystemPrompt();
-        _logger.LogInformation("[{Provider}] System prompts assembled (multi-file: {MultiLen} chars, single-file: {SingleLen} chars, pr-summary: {SumLen} chars, max input lines/file: {MaxLines})",
-            modelName, _systemPrompt.Length, _singleFileSystemPrompt.Length, _prSummarySystemPrompt.Length, _maxInputLinesPerFile);
+        _logger.LogInformation("[{Provider}] System prompts assembled (multi-file: {MultiLen} chars, single-file: {SingleLen} chars, pr-summary: {SumLen} chars, max input lines/file: {MaxLines}, temperature: {Temp}, batch tokens: {BatchTok}, single-file tokens: {SFTok})",
+            modelName, _systemPrompt.Length, _singleFileSystemPrompt.Length, _prSummarySystemPrompt.Length,
+            _maxInputLinesPerFile, _reviewProfile.Temperature, _reviewProfile.MaxOutputTokensBatch, _reviewProfile.MaxOutputTokensSingleFile);
     }
 
     public async Task<CodeReviewResult> ReviewAsync(PullRequestInfo pullRequest, List<FileChange> fileChanges, List<WorkItemInfo>? workItems = null)
@@ -79,8 +84,8 @@ public class AzureOpenAiReviewService : ICodeReviewService
 
         var options = new ChatCompletionOptions
         {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 16000,
+            Temperature = _reviewProfile.Temperature,
+            MaxOutputTokenCount = _reviewProfile.MaxOutputTokensBatch,
             ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat(),
         };
 
@@ -165,8 +170,8 @@ public class AzureOpenAiReviewService : ICodeReviewService
 
         var options = new ChatCompletionOptions
         {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 4000,  // single file needs fewer tokens
+            Temperature = _reviewProfile.Temperature,
+            MaxOutputTokenCount = _reviewProfile.MaxOutputTokensSingleFile,
             ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat(),
         };
 
@@ -266,8 +271,8 @@ public class AzureOpenAiReviewService : ICodeReviewService
 
         var options = new ChatCompletionOptions
         {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 2000,
+            Temperature = _reviewProfile.Temperature,
+            MaxOutputTokenCount = _reviewProfile.MaxOutputTokensVerification,
             ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat(),
         };
 
@@ -452,8 +457,8 @@ public class AzureOpenAiReviewService : ICodeReviewService
 
         var options = new ChatCompletionOptions
         {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 4000,
+            Temperature = _reviewProfile.Temperature,
+            MaxOutputTokenCount = _reviewProfile.MaxOutputTokensPrSummary,
             ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat(),
         };
 

--- a/src/HVO.AiCodeReview/Services/CodeReviewServiceFactory.cs
+++ b/src/HVO.AiCodeReview/Services/CodeReviewServiceFactory.cs
@@ -27,6 +27,10 @@ public static class CodeReviewServiceFactory
         services.Configure<AiProviderSettings>(
             configuration.GetSection(AiProviderSettings.SectionName));
 
+        // Bind review profile (temperature, tokens, thresholds)
+        services.Configure<ReviewProfile>(
+            configuration.GetSection(ReviewProfile.SectionName));
+
         // Keep legacy AzureOpenAISettings binding for backward compatibility
         // (used by the legacy AzureOpenAiReviewService constructor)
         services.Configure<AzureOpenAISettings>(
@@ -35,6 +39,7 @@ public static class CodeReviewServiceFactory
         services.AddSingleton<ICodeReviewService>(sp =>
         {
             var settings = sp.GetRequiredService<IOptions<AiProviderSettings>>().Value;
+            var reviewProfile = sp.GetRequiredService<IOptions<ReviewProfile>>().Value;
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
 
             // ── Fallback: if no AiProvider section exists, use legacy AzureOpenAI ──
@@ -53,7 +58,8 @@ public static class CodeReviewServiceFactory
                     legacySettings.DeploymentName,
                     legacySettings.CustomInstructionsPath,
                     logger,
-                    maxInputLinesPerFile: settings.MaxInputLinesPerFile);
+                    maxInputLinesPerFile: settings.MaxInputLinesPerFile,
+                    reviewProfile: reviewProfile);
             }
 
             // Build all enabled providers
@@ -61,7 +67,7 @@ public static class CodeReviewServiceFactory
                 .Where(kv => kv.Value.Enabled)
                 .Select(kv => (
                     Name: kv.Value.DisplayName.Length > 0 ? kv.Value.DisplayName : kv.Key,
-                    Service: CreateProvider(kv.Key, kv.Value, loggerFactory, settings.MaxInputLinesPerFile)))
+                    Service: CreateProvider(kv.Key, kv.Value, loggerFactory, settings.MaxInputLinesPerFile, reviewProfile)))
                 .ToList();
 
             if (providers.Count == 0)
@@ -116,7 +122,8 @@ public static class CodeReviewServiceFactory
     /// Extend this method when adding new provider types.
     /// </summary>
     private static ICodeReviewService CreateProvider(
-        string key, ProviderConfig config, ILoggerFactory loggerFactory, int globalMaxInputLines)
+        string key, ProviderConfig config, ILoggerFactory loggerFactory, int globalMaxInputLines,
+        ReviewProfile reviewProfile)
     {
         var type = config.Type.ToLowerInvariant();
         var maxLines = config.MaxInputLinesPerFile ?? globalMaxInputLines;
@@ -129,7 +136,8 @@ public static class CodeReviewServiceFactory
                 config.Model,
                 config.CustomInstructionsPath,
                 loggerFactory.CreateLogger<AzureOpenAiReviewService>(),
-                maxInputLinesPerFile: maxLines),
+                maxInputLinesPerFile: maxLines,
+                reviewProfile: reviewProfile),
 
             // ── Add new provider types here ──────────────────────────────
             // "github-copilot" => new GitHubCopilotReviewService(config, loggerFactory.CreateLogger<GitHubCopilotReviewService>()),

--- a/src/HVO.AiCodeReview/appsettings.json
+++ b/src/HVO.AiCodeReview/appsettings.json
@@ -37,5 +37,12 @@
         "Enabled": true
       }
     }
+  },
+  "ReviewProfile": {
+    "Temperature": 0.1,
+    "MaxOutputTokensBatch": 16000,
+    "MaxOutputTokensSingleFile": 4000,
+    "MaxOutputTokensVerification": 2000,
+    "MaxOutputTokensPrSummary": 4000
   }
 }

--- a/tests/HVO.AiCodeReview.Tests/ReviewProfileTests.cs
+++ b/tests/HVO.AiCodeReview.Tests/ReviewProfileTests.cs
@@ -1,0 +1,290 @@
+using AiCodeReview.Models;
+using AiCodeReview.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Reflection;
+
+namespace AiCodeReview.Tests;
+
+/// <summary>
+/// Tests for Issue #8 — Configurable Review Profile.
+/// Validates that Temperature, MaxOutputTokens*, and VerdictThresholds
+/// flow correctly from configuration through the factory to the service.
+/// </summary>
+[TestClass]
+public class ReviewProfileTests
+{
+    // ── AC-1: Defaults match previous hardcoded values ─────────────────
+
+    [TestMethod]
+    public void ReviewProfile_Defaults_MatchHardcodedValues()
+    {
+        var profile = new ReviewProfile();
+
+        Assert.AreEqual(0.1f, profile.Temperature, "Default temperature must be 0.1.");
+        Assert.AreEqual(16000, profile.MaxOutputTokensBatch, "Default batch tokens must be 16000.");
+        Assert.AreEqual(4000, profile.MaxOutputTokensSingleFile, "Default single-file tokens must be 4000.");
+        Assert.AreEqual(2000, profile.MaxOutputTokensVerification, "Default verification tokens must be 2000.");
+        Assert.AreEqual(4000, profile.MaxOutputTokensPrSummary, "Default PR summary tokens must be 4000.");
+    }
+
+    [TestMethod]
+    public void VerdictThresholds_Defaults_AreReasonable()
+    {
+        var thresholds = new VerdictThresholds();
+
+        Assert.AreEqual(1, thresholds.RejectOnCriticalCount, "Default reject-on-critical must be 1.");
+        Assert.AreEqual(3, thresholds.NeedsWorkOnWarningCount, "Default needs-work-on-warning must be 3.");
+    }
+
+    [TestMethod]
+    public void ReviewProfile_SectionName_IsCorrect()
+    {
+        Assert.AreEqual("ReviewProfile", ReviewProfile.SectionName);
+    }
+
+    // ── AC-2: Config binding from appsettings ──────────────────────────
+
+    [TestMethod]
+    public void Config_Binds_AllReviewProfileValues()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ReviewProfile:Temperature"] = "0.3",
+                ["ReviewProfile:MaxOutputTokensBatch"] = "20000",
+                ["ReviewProfile:MaxOutputTokensSingleFile"] = "6000",
+                ["ReviewProfile:MaxOutputTokensVerification"] = "3000",
+                ["ReviewProfile:MaxOutputTokensPrSummary"] = "5000",
+            })
+            .Build();
+
+        var profile = config.GetSection("ReviewProfile").Get<ReviewProfile>()!;
+
+        Assert.AreEqual(0.3f, profile.Temperature, 0.001f);
+        Assert.AreEqual(20000, profile.MaxOutputTokensBatch);
+        Assert.AreEqual(6000, profile.MaxOutputTokensSingleFile);
+        Assert.AreEqual(3000, profile.MaxOutputTokensVerification);
+        Assert.AreEqual(5000, profile.MaxOutputTokensPrSummary);
+    }
+
+    [TestMethod]
+    public void Config_Binds_VerdictThresholds()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ReviewProfile:VerdictThresholds:RejectOnCriticalCount"] = "2",
+                ["ReviewProfile:VerdictThresholds:NeedsWorkOnWarningCount"] = "5",
+            })
+            .Build();
+
+        var profile = config.GetSection("ReviewProfile").Get<ReviewProfile>()!;
+
+        Assert.AreEqual(2, profile.VerdictThresholds.RejectOnCriticalCount);
+        Assert.AreEqual(5, profile.VerdictThresholds.NeedsWorkOnWarningCount);
+    }
+
+    [TestMethod]
+    public void Config_PartialBinding_UsesDefaults()
+    {
+        // Only set Temperature — everything else should be default
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ReviewProfile:Temperature"] = "0.5",
+            })
+            .Build();
+
+        var profile = config.GetSection("ReviewProfile").Get<ReviewProfile>()!;
+
+        Assert.AreEqual(0.5f, profile.Temperature, 0.001f, "Explicitly set value should apply.");
+        Assert.AreEqual(16000, profile.MaxOutputTokensBatch, "Unset value should use default.");
+        Assert.AreEqual(4000, profile.MaxOutputTokensSingleFile, "Unset value should use default.");
+        Assert.AreEqual(2000, profile.MaxOutputTokensVerification, "Unset value should use default.");
+        Assert.AreEqual(4000, profile.MaxOutputTokensPrSummary, "Unset value should use default.");
+    }
+
+    [TestMethod]
+    public void Config_EmptySection_UsesAllDefaults()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { })
+            .Build();
+
+        var profile = config.GetSection("ReviewProfile").Get<ReviewProfile>() ?? new ReviewProfile();
+
+        Assert.AreEqual(0.1f, profile.Temperature, 0.001f);
+        Assert.AreEqual(16000, profile.MaxOutputTokensBatch);
+    }
+
+    // ── AC-3: Service uses ReviewProfile values ────────────────────────
+
+    [TestMethod]
+    public void Service_StoresReviewProfile()
+    {
+        var profile = new ReviewProfile
+        {
+            Temperature = 0.5f,
+            MaxOutputTokensBatch = 20000,
+        };
+
+        var service = CreateServiceWithProfile(profile);
+        var storedProfile = GetPrivateField<ReviewProfile>(service, "_reviewProfile");
+
+        Assert.AreEqual(0.5f, storedProfile.Temperature, 0.001f);
+        Assert.AreEqual(20000, storedProfile.MaxOutputTokensBatch);
+    }
+
+    [TestMethod]
+    public void Service_DefaultProfile_WhenNullPassed()
+    {
+        var service = CreateServiceWithProfile(reviewProfile: null);
+        var storedProfile = GetPrivateField<ReviewProfile>(service, "_reviewProfile");
+
+        Assert.IsNotNull(storedProfile, "A null ReviewProfile should result in a default instance.");
+        Assert.AreEqual(0.1f, storedProfile.Temperature, 0.001f);
+        Assert.AreEqual(16000, storedProfile.MaxOutputTokensBatch);
+    }
+
+    // ── AC-4: Factory wires ReviewProfile through DI ───────────────────
+
+    [TestMethod]
+    public void Factory_PassesReviewProfileToProvider()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AiProvider:Mode"] = "single",
+                ["AiProvider:ActiveProvider"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Type"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Endpoint"] = "https://fake.openai.azure.com/",
+                ["AiProvider:Providers:azure-openai:ApiKey"] = "fake-key",
+                ["AiProvider:Providers:azure-openai:Model"] = "gpt-4o",
+                ["AiProvider:Providers:azure-openai:Enabled"] = "true",
+                ["ReviewProfile:Temperature"] = "0.7",
+                ["ReviewProfile:MaxOutputTokensBatch"] = "32000",
+                ["ReviewProfile:MaxOutputTokensSingleFile"] = "8000",
+                ["ReviewProfile:MaxOutputTokensVerification"] = "4000",
+                ["ReviewProfile:MaxOutputTokensPrSummary"] = "6000",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddCodeReviewService(config);
+
+        var sp = services.BuildServiceProvider();
+        var service = sp.GetRequiredService<ICodeReviewService>();
+        Assert.IsInstanceOfType(service, typeof(AzureOpenAiReviewService));
+
+        var profile = GetPrivateField<ReviewProfile>((AzureOpenAiReviewService)service, "_reviewProfile");
+        Assert.AreEqual(0.7f, profile.Temperature, 0.001f, "Temperature must flow from config through factory.");
+        Assert.AreEqual(32000, profile.MaxOutputTokensBatch, "MaxOutputTokensBatch must flow from config.");
+        Assert.AreEqual(8000, profile.MaxOutputTokensSingleFile, "MaxOutputTokensSingleFile must flow from config.");
+        Assert.AreEqual(4000, profile.MaxOutputTokensVerification, "MaxOutputTokensVerification must flow from config.");
+        Assert.AreEqual(6000, profile.MaxOutputTokensPrSummary, "MaxOutputTokensPrSummary must flow from config.");
+    }
+
+    [TestMethod]
+    public void Factory_UsesDefaultProfile_WhenNoConfigSection()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AiProvider:Mode"] = "single",
+                ["AiProvider:ActiveProvider"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Type"] = "azure-openai",
+                ["AiProvider:Providers:azure-openai:Endpoint"] = "https://fake.openai.azure.com/",
+                ["AiProvider:Providers:azure-openai:ApiKey"] = "fake-key",
+                ["AiProvider:Providers:azure-openai:Model"] = "gpt-4o",
+                ["AiProvider:Providers:azure-openai:Enabled"] = "true",
+                // No ReviewProfile section
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddCodeReviewService(config);
+
+        var sp = services.BuildServiceProvider();
+        var service = (AzureOpenAiReviewService)sp.GetRequiredService<ICodeReviewService>();
+        var profile = GetPrivateField<ReviewProfile>(service, "_reviewProfile");
+
+        Assert.AreEqual(0.1f, profile.Temperature, 0.001f, "Missing config should use default temperature.");
+        Assert.AreEqual(16000, profile.MaxOutputTokensBatch, "Missing config should use default batch tokens.");
+    }
+
+    [TestMethod]
+    public void Factory_LegacyFallback_StillPassesReviewProfile()
+    {
+        // No AiProvider:Providers — triggers legacy path
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureOpenAI:Endpoint"] = "https://fake.openai.azure.com/",
+                ["AzureOpenAI:ApiKey"] = "fake-key",
+                ["AzureOpenAI:DeploymentName"] = "gpt-4o",
+                ["ReviewProfile:Temperature"] = "0.2",
+                ["ReviewProfile:MaxOutputTokensBatch"] = "12000",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddCodeReviewService(config);
+
+        var sp = services.BuildServiceProvider();
+        var service = (AzureOpenAiReviewService)sp.GetRequiredService<ICodeReviewService>();
+        var profile = GetPrivateField<ReviewProfile>(service, "_reviewProfile");
+
+        Assert.AreEqual(0.2f, profile.Temperature, 0.001f, "Legacy path should also receive ReviewProfile.");
+        Assert.AreEqual(12000, profile.MaxOutputTokensBatch, "Legacy path should pass configured batch tokens.");
+    }
+
+    // ── AC-5: appsettings.json contains ReviewProfile section ──────────
+
+    [TestMethod]
+    public void AppSettingsJson_ContainsReviewProfileSection()
+    {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(Path.GetFullPath(
+                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..",
+                    "src", "HVO.AiCodeReview")))
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var profile = config.GetSection("ReviewProfile").Get<ReviewProfile>();
+        Assert.IsNotNull(profile, "appsettings.json must contain a ReviewProfile section.");
+        Assert.AreEqual(0.1f, profile.Temperature, 0.001f, "Default temperature in appsettings.json should be 0.1.");
+        Assert.AreEqual(16000, profile.MaxOutputTokensBatch);
+        Assert.AreEqual(4000, profile.MaxOutputTokensSingleFile);
+        Assert.AreEqual(2000, profile.MaxOutputTokensVerification);
+        Assert.AreEqual(4000, profile.MaxOutputTokensPrSummary);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static AzureOpenAiReviewService CreateServiceWithProfile(ReviewProfile? reviewProfile)
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
+        return new AzureOpenAiReviewService(
+            "https://fake.openai.azure.com/",
+            "fake-key",
+            "gpt-4o",
+            customInstructionsPath: null,
+            loggerFactory.CreateLogger<AzureOpenAiReviewService>(),
+            maxInputLinesPerFile: 5000,
+            reviewProfile: reviewProfile);
+    }
+
+    private static T GetPrivateField<T>(object instance, string fieldName)
+    {
+        var field = instance.GetType()
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field, $"Private field '{fieldName}' must exist.");
+        return (T)field.GetValue(instance)!;
+    }
+}


### PR DESCRIPTION
## Summary
Implements issue #8 — Configurable Review Profile.

Moves hardcoded Temperature and MaxOutputTokenCount values into a configurable `ReviewProfile` section, allowing operators to tune AI review behaviour without code changes.

## Changes
- **ReviewProfile model**: Temperature, MaxOutputTokensBatch/SingleFile/Verification/PrSummary, VerdictThresholds (aspirational)
- **AzureOpenAiReviewService**: All 4 ChatCompletionOptions blocks now use `_reviewProfile.*` fields instead of hardcoded values
- **CodeReviewServiceFactory**: Binds `ReviewProfile` from config, passes through both provider and legacy paths
- **appsettings.json**: New `ReviewProfile` section with backward-compatible defaults

## Tests
13 new unit tests covering:
- Default values match previous hardcoded behaviour
- Config binding (full, partial, empty, VerdictThresholds)
- Factory wiring (provider path + legacy fallback)
- appsettings.json section validation

All 110 tests pass (107 passed, 3 skipped integration).

Closes #8