### PR TITLE
fix: add missing ArchitectureContextProvider DI registration in ServiceIntegrationTests

### DIFF
--- a/tests/HVO.AiCodeReview.Tests/ServiceIntegrationTests.cs
+++ b/tests/HVO.AiCodeReview.Tests/ServiceIntegrationTests.cs
@@ -65,6 +65,7 @@ public class ServiceIntegrationTests
         services.Configure<TestCoverageSettings>(config.GetSection(TestCoverageSettings.SectionName));
         services.AddSingleton<TestCoverageGapDetector>();
         services.AddScoped<VectorStoreReviewService>();
+        services.AddScoped<ArchitectureContextProvider>();
         services.AddTransient<CodeReviewOrchestrator>();
 
         var sp = services.BuildServiceProvider();


### PR DESCRIPTION
## Summary

`ServiceIntegrationTests.BuildServices()` was missing the `ArchitectureContextProvider` DI registration, causing all 7 tests in the class to fail with:

```
System.InvalidOperationException: Unable to resolve service for type
'AiCodeReview.Services.ArchitectureContextProvider' while attempting
to activate 'AiCodeReview.Services.CodeReviewOrchestrator'.
```

## Fix

Added `services.AddScoped<ArchitectureContextProvider>()` to match `Program.cs` and `TestServiceBuilder.cs`.

## Test Results

| Suite | Before | After |
|-------|--------|-------|
| Unit/Integration (non-live) | 943 passed | 943 passed |
| LiveAI | 10 passed | 10 passed |
| LiveDevOps | 25 passed, **7 failed** | **32 passed**, 0 failed |
