### PR TITLE
fix: forceReview/simulationOnly incorrectly labels first review as Re-Review

### DIFF
--- a/src/HVO.AiCodeReview/Services/CodeReviewOrchestrator.cs
+++ b/src/HVO.AiCodeReview/Services/CodeReviewOrchestrator.cs
@@ -173,7 +173,7 @@ public class CodeReviewOrchestrator : ICodeReviewOrchestrator
 
             // ── Step 2: Decide what action to take ──────────────────────────
             var action = (forceReview || simulationOnly)
-                ? ReviewAction.ReReview
+                ? (metadata.HasPreviousReview ? ReviewAction.ReReview : ReviewAction.FullReview)
                 : DetermineAction(prInfo, metadata, currentIteration);
 
             if (forceReview)

--- a/tests/HVO.AiCodeReview.Tests/OrchestratorCoverageTests.cs
+++ b/tests/HVO.AiCodeReview.Tests/OrchestratorCoverageTests.cs
@@ -407,6 +407,89 @@ public class OrchestratorCoverageTests
     }
 
     // ═══════════════════════════════════════════════════════════════════
+    //  Action label: Full Review vs Re-Review (force/simulation)
+    // ═══════════════════════════════════════════════════════════════════
+
+    [TestMethod]
+    public async Task ForceReview_NoPriorMetadata_RecordsFullReview()
+    {
+        var fakeDevOps = new FakeDevOpsService();
+        SeedStandardPr(fakeDevOps);
+        await using var ctx = TestServiceBuilder.BuildFullyFake(fakeDevOps: fakeDevOps);
+
+        var result = await ctx.Orchestrator.ExecuteReviewAsync(
+            Project, Repo, PrId, forceReview: true);
+
+        Assert.AreEqual("Reviewed", result.Status);
+
+        var history = await fakeDevOps.GetReviewHistoryAsync(Project, Repo, PrId);
+        Assert.AreEqual(1, history.Count, "Exactly one history entry expected.");
+        Assert.AreEqual("Full Review", history[0].Action,
+            "First review with forceReview should record 'Full Review', not 'Re-Review'.");
+    }
+
+    [TestMethod]
+    public async Task Simulation_NoPriorMetadata_SummaryShowsFullReview()
+    {
+        var fakeDevOps = new FakeDevOpsService();
+        SeedStandardPr(fakeDevOps);
+        await using var ctx = TestServiceBuilder.BuildFullyFake(fakeDevOps: fakeDevOps);
+
+        var result = await ctx.Orchestrator.ExecuteReviewAsync(
+            Project, Repo, PrId, simulationOnly: true);
+
+        Assert.AreEqual("Simulated", result.Status);
+        Assert.IsNotNull(result.Summary, "Simulation should produce a summary.");
+        Assert.IsFalse(result.Summary.Contains("Re-Review"),
+            "First simulation with no prior metadata should not show 'Re-Review' in summary.");
+    }
+
+    [TestMethod]
+    public async Task ForceReview_WithPriorMetadata_RecordsReReview()
+    {
+        var fakeDevOps = new FakeDevOpsService();
+        SeedStandardPr(fakeDevOps);
+        await using var ctx = TestServiceBuilder.BuildFullyFake(fakeDevOps: fakeDevOps);
+
+        // Seed prior review metadata
+        await fakeDevOps.SetReviewMetadataAsync(Project, Repo, PrId, new ReviewMetadata
+        {
+            ReviewCount = 1,
+            ReviewedAtUtc = DateTime.UtcNow.AddMinutes(-30),
+            LastReviewedSourceCommit = "old-commit-sha",
+            LastReviewedIteration = 1,
+            VoteSubmitted = true,
+        });
+
+        var result = await ctx.Orchestrator.ExecuteReviewAsync(
+            Project, Repo, PrId, forceReview: true);
+
+        Assert.AreEqual("Reviewed", result.Status);
+
+        var history = await fakeDevOps.GetReviewHistoryAsync(Project, Repo, PrId);
+        Assert.IsTrue(history.Count >= 1, "At least one history entry expected.");
+        Assert.AreEqual("Re-Review", history[^1].Action,
+            "Review with prior metadata and forceReview should record 'Re-Review'.");
+    }
+
+    [TestMethod]
+    public async Task NormalFirstReview_NoPriorMetadata_RecordsFullReview()
+    {
+        var fakeDevOps = new FakeDevOpsService();
+        SeedStandardPr(fakeDevOps);
+        await using var ctx = TestServiceBuilder.BuildFullyFake(fakeDevOps: fakeDevOps);
+
+        var result = await ctx.Orchestrator.ExecuteReviewAsync(Project, Repo, PrId);
+
+        Assert.AreEqual("Reviewed", result.Status);
+
+        var history = await fakeDevOps.GetReviewHistoryAsync(Project, Repo, PrId);
+        Assert.AreEqual(1, history.Count, "Exactly one history entry expected.");
+        Assert.AreEqual("Full Review", history[0].Action,
+            "First review without forceReview should record 'Full Review'.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
     //  Helpers
     // ═══════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Problem

When `forceReview` or `simulationOnly` was set on the API call, the orchestrator unconditionally forced the review action to `ReReview`, even when no prior review existed for the PR. This caused the first-ever review of a PR to incorrectly show:

- **Action**: "Re-Review" instead of "Full Review"
- **Summary title**: "## Re-Review (Review 1)" instead of "## Code Review (Review 1)"

The issue was in `CodeReviewOrchestrator.ExecuteReviewAsync` at the action determination step:

```csharp
// Before: always forced to ReReview
var action = (forceReview || simulationOnly)
    ? ReviewAction.ReReview
    : DetermineAction(prInfo, metadata, currentIteration);
```

## Fix

Now checks `metadata.HasPreviousReview` to correctly determine `FullReview` vs `ReReview` when bypassing the normal `DetermineAction` logic:

```csharp
// After: respects whether prior review exists
var action = (forceReview || simulationOnly)
    ? (metadata.HasPreviousReview ? ReviewAction.ReReview : ReviewAction.FullReview)
    : DetermineAction(prInfo, metadata, currentIteration);
```

## Tests Added

4 new tests in `OrchestratorCoverageTests`:

| Test | Scenario |
|------|----------|
| `ForceReview_NoPriorMetadata_RecordsFullReview` | First review with `forceReview: true` → history records "Full Review" |
| `Simulation_NoPriorMetadata_SummaryShowsFullReview` | First simulation → summary does not contain "Re-Review" |
| `ForceReview_WithPriorMetadata_RecordsReReview` | Subsequent `forceReview` with existing metadata → correctly records "Re-Review" |
| `NormalFirstReview_NoPriorMetadata_RecordsFullReview` | Baseline: normal first review → "Full Review" |

## Verification

- Build: 0 warnings, 0 errors
- Tests: 992 passed, 0 failed, 3 skipped (pre-existing)
